### PR TITLE
Ask before trying to refresh a disabled plugin

### DIFF
--- a/addons/godot-plugin-refresher/plugin_refresher.gd
+++ b/addons/godot-plugin-refresher/plugin_refresher.gd
@@ -5,6 +5,7 @@ const ADDONS_PATH = "res://addons/"
 const PLUGIN_PATH = "godot-plugin-refresher"
 
 signal request_refresh_plugin(p_name)
+signal confirm_refresh_plugin(p_name)
 
 onready var options = $OptionButton
 
@@ -34,6 +35,7 @@ func select_plugin(p_name):
 		var plugin = options.get_item_text(idx)
 		if plugin == p_name:
 			options.selected = options.get_item_id(idx)
+			break
 
 func set_refresh_button_icon(p_icon):
 	$RefreshButton.icon = p_icon
@@ -46,3 +48,14 @@ func _on_RefreshButton_pressed():
 	if not plugin or plugin.empty():
 		return
 	emit_signal("request_refresh_plugin", plugin)
+
+func show_warning(p_name):
+	$ConfirmationDialog.dialog_text = """
+		Plugin `%s` is currently disabled.\n
+		Do you want to enable it now?
+	""" % [p_name]
+	$ConfirmationDialog.popup_centered()
+
+func _on_ConfirmationDialog_confirmed():
+	var plugin = options.get_item_text(options.selected)
+	emit_signal('confirm_refresh_plugin', plugin)

--- a/addons/godot-plugin-refresher/plugin_refresher.tscn
+++ b/addons/godot-plugin-refresher/plugin_refresher.tscn
@@ -21,5 +21,12 @@ rect_min_size = Vector2( 150, 0 )
 margin_left = 162.0
 margin_right = 174.0
 margin_bottom = 40.0
-
 [connection signal="pressed" from="RefreshButton" to="." method="_on_RefreshButton_pressed"]
+
+[node name="ConfirmationDialog" type="ConfirmationDialog" parent="."]
+margin_right = 278.0
+margin_bottom = 110.0
+rect_min_size = Vector2( 300, 70 )
+window_title = "Plugin Refresher"
+dialog_autowrap = true
+[connection signal="confirmed" from="ConfirmationDialog" to="." method="_on_ConfirmationDialog_confirmed"]

--- a/addons/godot-plugin-refresher/plugin_refresher_plugin.gd
+++ b/addons/godot-plugin-refresher/plugin_refresher_plugin.gd
@@ -29,6 +29,7 @@ func _enter_tree():
 	efs.connect("filesystem_changed", self, "_on_filesystem_changed")
 
 	refresher.connect("request_refresh_plugin", self, "_on_request_refresh_plugin")
+	refresher.connect("confirm_refresh_plugin", self, "_on_confirm_refresh_plugin")
 
 	_load_settings()
 
@@ -71,11 +72,24 @@ func get_recent_plugin():
 	return recent
 
 func _on_request_refresh_plugin(p_name):
-	print("Refreshing plugin: ", p_name)
-
 	assert(not p_name.empty())
 
-	get_editor_interface().set_plugin_enabled(p_name, false)
+	var disabled = not get_editor_interface().is_plugin_enabled(p_name)
+	if disabled:
+		refresher.show_warning(p_name)
+	else:
+		refresh_plugin(p_name)
+
+func _on_confirm_refresh_plugin(p_name):
+	refresh_plugin(p_name)
+
+func refresh_plugin(p_name):
+	print("Refreshing plugin: ", p_name)
+
+	var enabled = get_editor_interface().is_plugin_enabled(p_name)
+	if enabled: # can only disable an active plugin
+		get_editor_interface().set_plugin_enabled(p_name, false)
+
 	get_editor_interface().set_plugin_enabled(p_name, true)
 
 	plugin_config.set_value(SETTINGS, SETTING_RECENT, p_name)


### PR DESCRIPTION
Closes #5.

A disabled plugin is still visible in the list, but if a requested plugin is initially disabled, the refresher will ask whether the user wants to enable it first.

![plugin_refresher_confirm](https://user-images.githubusercontent.com/17108460/62228408-44c26d80-b3c6-11e9-8e47-947f718e9e5c.png)
