### PR TITLE
Simplify the way reload icon is set from current theme

### DIFF
--- a/addons/godot-plugin-refresher/plugin_refresher.gd
+++ b/addons/godot-plugin-refresher/plugin_refresher.gd
@@ -10,6 +10,7 @@ signal confirm_refresh_plugin(p_name)
 onready var options = $OptionButton
 
 func _ready():
+	$RefreshButton.icon = get_icon('Reload', 'EditorIcons')
 	reload_items()
 
 func reload_items():
@@ -36,9 +37,6 @@ func select_plugin(p_name):
 		if plugin == p_name:
 			options.selected = options.get_item_id(idx)
 			break
-
-func set_refresh_button_icon(p_icon):
-	$RefreshButton.icon = p_icon
 
 func _on_RefreshButton_pressed():
 	if options.selected == -1:

--- a/addons/godot-plugin-refresher/plugin_refresher_plugin.gd
+++ b/addons/godot-plugin-refresher/plugin_refresher_plugin.gd
@@ -16,16 +16,8 @@ func _enter_tree():
 	refresher = PluginRefresherScn.instance()
 	add_control_to_container(CONTAINER_TOOLBAR, refresher)
 
-	var eds = get_editor_interface()
-
-	# Set reload icon from Godot's own theme
-	var godot_editor = eds.get_base_control()
-	var reload_icon = godot_editor.theme.get_icon('Reload', 'EditorIcons')
-	assert(reload_icon != null)
-	refresher.set_refresh_button_icon(reload_icon)
-
 	# Watch whether any plugin is changed, added or removed on the filesystem
-	var efs = eds.get_resource_filesystem()
+	var efs = get_editor_interface().get_resource_filesystem()
 	efs.connect("filesystem_changed", self, "_on_filesystem_changed")
 
 	refresher.connect("request_refresh_plugin", self, "_on_request_refresh_plugin")


### PR DESCRIPTION
Controls inherit parent's theme by default, so there's no need to retrieve the theme from base control (can still be useful in cases when operating within an editor plugin itself or when the theme is overridden per control, but not in this case).

Learning every time!